### PR TITLE
fix: use debian-based bun image for build to fix glibc compatibility

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -85,7 +85,8 @@ jobs:
             docker compose down --remove-orphans || true
 
             echo "🔨 Building & starting containers..."
-            docker compose up -d --build --remove-orphans
+            docker compose build --no-cache app
+            docker compose up -d --remove-orphans
 
             echo "⏳ Waiting for containers to start..."
 
@@ -205,7 +206,7 @@ jobs:
               exit 0
             fi
 
-            if docker compose exec -T app wget -qO- http://localhost:3000/health; then
+            if docker compose exec -T app curl -sf http://localhost:3000/health; then
               echo "✅ Health OK (app)"
               exit 0
             fi

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,7 +7,7 @@
 # -----------------------------------------------------------------------------
 # Build stage - Alpine with Bun
 # -----------------------------------------------------------------------------
-FROM --platform=linux/amd64 oven/bun:1.1.43-alpine AS build
+FROM --platform=linux/amd64 oven/bun:1.1.43-debian AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
- Changed build image from oven/bun:1.1.43-alpine to oven/bun:1.1.43-debian
- Add --no-cache to force rebuild of app image
- Fix verify step to use curl instead of wget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment build process with targeted container compilation
  * Improved deployment health verification mechanism
  * Updated runtime environment base image

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->