### PR TITLE
fix(sitemap): change cache strategy from no-store to force-cache for improved resource fetching

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -49,6 +49,9 @@ async function fetchResourcesPage(cursor?: string) {
   const response = await fetch(url.toString(), {
     method: "GET",
     cache: "force-cache",
+    next: {
+      revalidate: 60 * 60 * 24 * 7,
+    },
     headers: {
       Accept: "application/json",
     },

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -4,7 +4,6 @@ import type { GetResourcesResponse } from "@/lib/types";
 import type { MetadataRoute } from "next";
 
 const BASE = (publicEnv.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, "");
-export const dynamic = "force-dynamic";
 /** Key pages for sitelinks: clear URLs Google can show under the main result */
 const staticPages: MetadataRoute.Sitemap = [
   {
@@ -49,7 +48,7 @@ async function fetchResourcesPage(cursor?: string) {
 
   const response = await fetch(url.toString(), {
     method: "GET",
-    cache: "no-store",
+    cache: "force-cache",
     headers: {
       Accept: "application/json",
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved sitemap generation by enabling caching and periodic revalidation of resource responses, reducing unnecessary API requests.
  * Switched sitemap route to default/static behavior to allow cached responses and more efficient generation, resulting in faster sitemap updates and lower server load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->